### PR TITLE
Fix webppl editor

### DIFF
--- a/chapters/03-02-models.Rmd
+++ b/chapters/03-02-models.Rmd
@@ -565,11 +565,11 @@ viz(Infer({model: function() {var K_urn = K[flip(theta) ? 1 : 0];
 <pre class=" CodeMirror-line " role="presentation">
 </pre>
 
-<!-- <script> -->
-<!-- // find all <pre> elements and set up the editor on them -->
-<!-- var preEls = Array.prototype.slice.call(document.getElementsByClassName("webppl")); -->
-<!-- preEls.map(function(el) { console.log(el); editor.setup(el, {language: 'webppl'}); }); -->
-<!-- </script> -->
+<script>
+// find all <pre> elements and set up the editor on them
+var preEls = Array.prototype.slice.call(document.getElementsByClassName("webppl"));
+preEls.map(function(el) { console.log(el); editor.setup(el, {language: 'webppl'}); });
+</script>
 
 
 ### T-Test Model: comparing two groups

--- a/webppl-editor.css
+++ b/webppl-editor.css
@@ -220,10 +220,10 @@
 /* PADDING */
 
 .CodeMirror-lines {
-  padding: 4px 0; /* Vertical padding around content */
+  padding: 4px 0 !important; /* Vertical padding around content */
 }
 .CodeMirror pre {
-  padding: 0 4px; /* Horizontal padding of content */
+  padding: 0 4px !important; /* Horizontal padding of content */
 }
 
 .CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
@@ -447,10 +447,10 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   /* Reset some styles that the rest of the page might have set */
   -moz-border-radius: 0; -webkit-border-radius: 0; border-radius: 0;
   border-width: 0;
-  background: transparent;
+  background: transparent !important;
   font-family: inherit;
   font-size: inherit;
-  margin: 0;
+  margin: 0 !important;
   white-space: pre;
   word-wrap: normal;
   line-height: inherit;


### PR DESCRIPTION
This PR fixes the Codemirror styles for editing webppl examples by adding some crude `!important` override tags.