### PR TITLE
minor changes to infix explanation

### DIFF
--- a/chapters/01-01-R-basics.Rmd
+++ b/chapters/01-01-R-basics.Rmd
@@ -96,13 +96,15 @@ Some functions can take an arbitrary number of arguments. The function `sum`, wh
 sum(1, 2, 3)
 ```
 
-Selected functions can also be called in **infix notation**. This applies to frequently recurring operations, such as mathematical operations or logical comparisons.
+Selected functions can also be expressed as operators in **infix notation**. This applies to frequently recurring operations, such as mathematical operations or logical comparisons.
 
 ```{r, eval = F}
 # both of these calls sum 1, 2, and 3 together
 sum(1, 2, 3)   # prefix notation
 1 + 2 + 3      # infix notation
 ```
+
+An expression like `3 + 5` is internally processed as the function ``` `+`(3, 5) ``` which is equivalent to `sum(3, 5)`.
 
 Section \@ref(Chap-01-01-functions) will list some of the most important built-in functions. It will also explain how to define your own functions.
 


### PR DESCRIPTION
changed `called` to `expressed` , because `call` sound more like a function call. Also mentioned the term operator.

Additionally added a sentence how this works internally. This was taught in the "Introduction to AI with Prolog" lecture. Therefore, might be easier for some students to make the connection that this is the same.

I hope the markdown syntax ``` `+`(3, 5) ``` works in the web book. I had some pandoc error during the Rmarkdown compilation process. So I only tested it in a VS Code preview